### PR TITLE
Fix `trending.languages`

### DIFF
--- a/lib/scraper.js
+++ b/lib/scraper.js
@@ -87,9 +87,12 @@ exports.languages = function languages (html) {
         normalizeWhitespace: true
     });
 
-    $('.select-menu-item-text.js-select-button-text.js-navigation-open').each(function onEach (index, elem) {
+    $('.language-filter-list + .js-select-menu a.select-menu-item').each(function onEach (index, elem) {
         elem = $(elem);
-        langs.push(elem.attr('href').split('=')[1]);
+
+        var href = elem.attr('href');
+        var hrefParts = href.split('/');
+        langs.push(hrefParts[hrefParts.length - 1]);
     });
 
     return langs;

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "author": "André König <andre.koenig@posteo.de>",
   "license": "MIT",
   "dependencies": {
-    "cheerio": "^0.17.0",
+    "cheerio": "^0.20.0",
     "mandatory": "^1.0.0",
     "verror": "^1.4.0"
   },

--- a/specs/index.spec.js
+++ b/specs/index.spec.js
@@ -63,6 +63,7 @@ describe('The "github-trending" library', function suite () {
             expect(err).to.be(null);
 
             expect(util.isArray(languages)).to.be(true);
+            expect(languages).to.not.contain('trending?since=monthly');
             expect(languages.length).not.to.be(0);
 
             done();


### PR DESCRIPTION
This closes #7. Also, adds tests for ignoring trending periods in
`trending.languages` and upgrades cheerio. I think it'd be a nice thing to enable https://nightli.es/; should take a second.