### PR TITLE
Timespans. Languages scrape fix. Stars object.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,16 @@ trending('rust', function (err, repositories) {
     console.log(repositories);
 });
 ```
+### Trending repositories (particular language and timespan)
+
+```js
+var trending = require('github-trending');
+
+// Available timespans - daily, weekly, monthly
+trending('rust', 'weekly', function (err, repositories) {
+    console.log(repositories);
+});
+```
 
 ### Available languages
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -32,7 +32,27 @@ var endpoint = 'https://github.com/trending';
  * data has been fetched. Invoked as `callback(err, repositories)`.
  *
  */
-function trending (language, callback) {
+function trending () {
+
+    var language;
+    var timespan;
+    var callback;
+
+    if (arguments.length === 3) {
+        language = arguments[0];
+        timespan = arguments[1];
+        callback = arguments[2];
+    }
+    else if (arguments.length === 2) {
+        language = arguments[0];
+        callback = arguments[1];
+    }
+    else {
+        callback = arguments[0];
+    }
+
+    language = (language || 'all').toLowerCase();
+    timespan = timespan || 'daily';
 
     function onResponse (err, html) {
         var repositories;
@@ -46,18 +66,10 @@ function trending (language, callback) {
         callback(null, repositories);
     }
 
-    if (typeof language === 'function') {
-        callback = language;
-
-        language = undefined;
-    }
-
     mandatory(callback)
         .is('function', 'Please define a proper callback function.');
 
-    language = (language || 'all').toLowerCase();
-
-    request(endpoint, {l: language}, onResponse);
+    request(endpoint, { l: language, since: timespan }, onResponse);
 }
 
 /**

--- a/lib/scraper.js
+++ b/lib/scraper.js
@@ -46,6 +46,7 @@ exports.repositories = function repositories (html) {
     });
 
     $('li.repo-list-item').each(function onEach() {
+
         var repository = {};
         var $elem = $(this);
         var language = $elem.find('.repo-list-meta').text().split('•');
@@ -57,9 +58,15 @@ exports.repositories = function repositories (html) {
         repository.owner = $elem.find('span.prefix').text();
         repository.description = $elem.find('p.repo-list-description').text().replace(/^\s\s*/, '').replace(/\s\s*$/, '');
         repository.url = 'https://github.com/' + repository.owner + '/' + repository.title;
-        repository.language = language.length === 3 ? language[0].trim() : '';
-        repository.star = language.length === 3 ? language[1].trim() : language[0].trim();
+        repository.language = language[0].trim();
+
+        repository.stars = {
+            count: parseInt(language[1].trim()),
+            text: language[1].trim()
+        };
+
         repos.push(repository);
+
     });
 
     return repos;
@@ -89,7 +96,7 @@ exports.languages = function languages (html) {
 
     $('.select-menu-item-text.js-select-button-text.js-navigation-open').each(function onEach (index, elem) {
         elem = $(elem);
-        langs.push(elem.attr('href').split('=')[1]);
+        langs.push(elem.text().trim());
     });
 
     return langs;

--- a/specs/index.spec.js
+++ b/specs/index.spec.js
@@ -58,6 +58,17 @@ describe('The "github-trending" library', function suite () {
         });
     });
 
+    it('should be able to fetch the trending repos of a particular language with a timespan', function test (done) {
+        trending('rust', 'weekly', function (err, repos) {
+            expect(err).to.be(null);
+
+            expect(util.isArray(repos)).to.be(true);
+            expect(repos.length).not.to.be(0);
+
+            done();
+        });
+    });
+
     it('should be able to fetch the languages for which trending repo data is available', function test (done) {
         trending.languages(function (err, languages) {
             expect(err).to.be(null);

--- a/specs/index.spec.js
+++ b/specs/index.spec.js
@@ -41,7 +41,7 @@ describe('The "github-trending" library', function suite () {
             expect(repository.description).not.to.be(undefined);
             expect(repository.url).not.to.be(undefined);
             expect(repository.language).not.to.be(undefined);
-            expect(repository.star).not.to.be(undefined)
+            expect(repository.stars).not.to.be(undefined)
 
             done();
         });


### PR DESCRIPTION
Allow for timespans (daily, weekly, monthly). Fixed languages scrape. Turned `repo.star` into `repo.stars` to include raw text and parsed start count as number.